### PR TITLE
FIX: Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUGS.yaml
+++ b/.github/ISSUE_TEMPLATE/BUGS.yaml
@@ -38,7 +38,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree that you have searched to see if the issue hasn't been documented all ready, and that I agree to follow the Code of Conduct
+      description: By submitting this issue, you agree that you have searched to see if the issue hasn't been documented all ready, and that you agree to follow the Code of Conduct.
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/FEATURES.yaml
+++ b/.github/ISSUE_TEMPLATE/FEATURES.yaml
@@ -19,7 +19,8 @@ body:
     attributes:
       label: Proposed solution
       description: Share how you feel this would benefit the project.
-    validations: true
+    validations: 
+      required: true
   - type: textarea
     id: additional-context
     attributes:
@@ -29,7 +30,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this feature request, you agree that you have searched to see if the feature hasn't been suggested already, and that I agree to follow the Code of Conduct
+      description: By submitting this feature request, you agree that you have searched to see if the feature hasn't been suggested already, and that you agree to follow the Code of Conduct.
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
There was a breaking issue (it's always DNS - but when it's not, it's YAML) on the FEATURES template, which needed resolved so it could be picked. I cleaned up the text a bit, and then added a config.yml file that makes sure the issue templates are used for new issues.